### PR TITLE
rename Metric.clear to Metric.onCollect

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ val scalaTestArtifact    = "org.scalatest"     %% "scalatest"           % "3.2.+
 val prometheusClient     = "io.prometheus"     % "simpleclient"         % prometheusVersion
 val prometheusCommon     = "io.prometheus"     % "simpleclient_common"  % prometheusVersion
 val prometheusHotSpot    = "io.prometheus"     % "simpleclient_hotspot" % prometheusVersion
-val logbackArtifact      = "ch.qos.logback"    % "logback-classic"      % "1.2.6"
+val logbackArtifact      = "ch.qos.logback"    % "logback-classic"      % "1.2.+"
 
 lazy val publishSettings = Seq(
   publishMavenStyle := true,

--- a/kineticpulse-metric/src/main/scala/com/salesforce/mce/kineticpulse/Metric.scala
+++ b/kineticpulse-metric/src/main/scala/com/salesforce/mce/kineticpulse/Metric.scala
@@ -140,7 +140,7 @@ trait Metric {
 
   def collect: Future[String]
 
-  def clear(): Unit
+  def onCollect(): Unit
 
 }
 
@@ -219,7 +219,7 @@ class PrometheusMetric @Inject() (implicit ec: ExecutionContext) extends Metric 
     writer.toString
   }
 
-  override def clear(): Unit = {}
+  override def onCollect(): Unit = {}
 
 }
 

--- a/kineticpulse-metric/src/main/scala/com/salesforce/mce/kineticpulse/MetricController.scala
+++ b/kineticpulse-metric/src/main/scala/com/salesforce/mce/kineticpulse/MetricController.scala
@@ -16,7 +16,7 @@ class MetricController @Inject() (
 
   def collect: Action[AnyContent] = Action.async { _: Request[AnyContent] =>
     val metricResults = metric.collect.map(output => Ok(output))
-    metricResults.onComplete(_ => metric.clear())
+    metricResults.onComplete(_ => metric.onCollect())
     metricResults
   }
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.1.2"
+ThisBuild / version := "0.1.3"


### PR DESCRIPTION

`clear()` <--- original method name is ambiguous as to whether for CollectorRegistry or on the Collectors in Metric.

rename to `onCollect()`

risk: low
