### PR TITLE
stop crossScalaVersions cross publishing to 2.12, keep only 2.13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
     # See: https://circleci.com/docs/2.0/configuration-reference/#docker-machine-macos-windows-executor
     docker:
       # specify the version you desire here
-      - image: circleci/openjdk:8-jdk
+      - image: circleci/openjdk:11.0
 
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
     # See: https://circleci.com/docs/2.0/configuration-reference/#docker-machine-macos-windows-executor
     docker:
       # specify the version you desire here
-      - image: circleci/openjdk:11.0
+      - image: cimg/openjdk:11.0
 
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images
@@ -48,7 +48,7 @@ jobs:
 
   publish:
     docker:
-      - image: circleci/openjdk:8-jdk
+      - image: cimg/openjdk:11.0
     steps:
       - checkout
       - run: gpg --version && (echo $PGP_SECRET | base64 --decode | gpg --import --no-tty --batch --yes) && gpg --list-secret-keys

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,5 @@
 val scala213Version = "2.13.15"
+val scala333Version = "3.3.3"
 val prometheusVersion = "0.16.+"
 
 val scalaTestArtifact    = "org.scalatest"     %% "scalatest"           % "3.2.+"    % Test
@@ -44,8 +45,13 @@ lazy val commonSettings = Seq(
     // that depend on shapeless (e.g., circe) https://github.com/scala/bug/issues/12072.
     // Disabling it for now.
     case Some((2, 13)) => Seq("-Xlint:-byname-implicit,_", "-deprecation", "-feature", "-Xlint", "-Xfatal-warnings")
+    case Some((3, 3)) => Seq()
     case _ => Seq("-deprecation", "-feature", "-Xlint", "-Xfatal-warnings")
   }),
+  crossScalaVersions := Seq(
+    scala213Version,
+    scala333Version
+  ),
   libraryDependencies += scalaTestArtifact,
   organization := "com.salesforce.mce",
   headerLicense := Some(HeaderLicense.Custom(

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,4 @@
-val scala212Version = "2.12.17"
-val scala213Version = "2.13.14"
+val scala213Version = "2.13.15"
 val prometheusVersion = "0.16.+"
 
 val scalaTestArtifact    = "org.scalatest"     %% "scalatest"           % "3.2.+"    % Test
@@ -47,10 +46,6 @@ lazy val commonSettings = Seq(
     case Some((2, 13)) => Seq("-Xlint:-byname-implicit,_", "-deprecation", "-feature", "-Xlint", "-Xfatal-warnings")
     case _ => Seq("-deprecation", "-feature", "-Xlint", "-Xfatal-warnings")
   }),
-  crossScalaVersions := Seq(
-    scala212Version,
-    scala213Version
-  ),
   libraryDependencies += scalaTestArtifact,
   organization := "com.salesforce.mce",
   headerLicense := Some(HeaderLicense.Custom(

--- a/kineticpulse-metric/src/main/scala/com/salesforce/mce/kineticpulse/MetricController.scala
+++ b/kineticpulse-metric/src/main/scala/com/salesforce/mce/kineticpulse/MetricController.scala
@@ -21,7 +21,7 @@ class MetricController @Inject() (
   ec: ExecutionContext
 ) extends AbstractController(cc) {
 
-  def collect: Action[AnyContent] = Action.async { _: Request[AnyContent] =>
+  def collect: Action[AnyContent] = Action.async { (_: Request[AnyContent]) =>
     val metricResults = metric.collect.map(output => Ok(output))
     metricResults.onComplete(_ => metric.onCollect())
     metricResults

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.2.6"
+ThisBuild / version := "0.2.7"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.2.7"
+ThisBuild / version := "0.3.0"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.2.5"
+ThisBuild / version := "0.2.6"


### PR DESCRIPTION
With pekko / play upgrade, the play-guice has support for Scala 3 and 2.13, thus kineticpulse publish for 2.13 only.